### PR TITLE
Update pylibvw.cc

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -105,7 +105,11 @@ void my_finish_example(vw_ptr all, example_ptr ec) {
 }
 
 void my_learn(vw_ptr all, example_ptr ec) {
-  all->learn(ec.get());
+  if (ec->test_only) {
+    all->l->predict(*ec);
+  } else {
+    all->learn(ec.get());
+  }
 }
 
 float my_learn_string(vw_ptr all, char*str) {


### PR DESCRIPTION
currently calling ex.learn() using the python interface updates the model even after calling ex.set_test_only(True)

now the bit is checked when calling learn and the learner's predict method is called instead of learn if the example is a test only example